### PR TITLE
Added option to add scope to the Oauth request.

### DIFF
--- a/BrockAllen.OAuth2/FacebookProvider.cs
+++ b/BrockAllen.OAuth2/FacebookProvider.cs
@@ -10,14 +10,21 @@ namespace BrockAllen.OAuth2
 {
     class FacebookProvider : Provider
     {
-        public FacebookProvider(string clientID, string clientSecret)
-            : base(ProviderType.Facebook,
-                "",
+        public FacebookProvider(string clientID, string clientSecret, string scope)
+            : base(ProviderType.Facebook,                
                 "https://www.facebook.com/dialog/oauth",
                 "https://graph.facebook.com/oauth/access_token",
                 "https://graph.facebook.com/me",
                 clientID, clientSecret)
         {
+            if (string.IsNullOrEmpty(scope))
+            {
+                Scope = "";
+            }
+            else
+            {
+                Scope = scope;
+            }
         }
 
         static Dictionary<string, string> supportedClaimTypes = new Dictionary<string, string>();

--- a/BrockAllen.OAuth2/GoogleProvider.cs
+++ b/BrockAllen.OAuth2/GoogleProvider.cs
@@ -9,14 +9,24 @@ namespace BrockAllen.OAuth2
 {
     class GoogleProvider : Provider
     {
-        public GoogleProvider(string clientID, string clientSecret)
-            : base(ProviderType.Google,
-                "https://www.googleapis.com/auth/userinfo.profile",
+
+
+        public GoogleProvider(string clientID, string clientSecret, string scope)
+            : base(ProviderType.Google,                
                 "https://accounts.google.com/o/oauth2/auth",
                 "https://accounts.google.com/o/oauth2/token",
                 "https://www.googleapis.com/oauth2/v1/userinfo",
                 clientID, clientSecret)
         {
+            if (string.IsNullOrEmpty(scope))
+            {
+                Scope = "https://www.googleapis.com/auth/userinfo.profile";
+            }
+            else
+            {
+                Scope = scope;
+            }
+
         }
 
         static Dictionary<string, string> supportedClaimTypes = new Dictionary<string, string>();

--- a/BrockAllen.OAuth2/LiveProvider.cs
+++ b/BrockAllen.OAuth2/LiveProvider.cs
@@ -9,14 +9,22 @@ namespace BrockAllen.OAuth2
 {
     class LiveProvider : Provider
     {
-        public LiveProvider(string clientID, string clientSecret)
+        public LiveProvider(string clientID, string clientSecret, string scope)
             : base(ProviderType.Live,
-                "wl.signin%20wl.basic",
                 "https://login.live.com/oauth20_authorize.srf",
                 "https://login.live.com/oauth20_token.srf",
                 "https://apis.live.net/v5.0/me", 
                 clientID, clientSecret)
         {
+
+            if (string.IsNullOrEmpty(scope))
+            {
+                Scope = "wl.signin%20wl.basic";
+            }
+            else
+            {
+                Scope = scope;
+            }
         }
 
         static Dictionary<string, string> supportedClaimTypes = new Dictionary<string, string>();

--- a/BrockAllen.OAuth2/OAuth2Client.cs
+++ b/BrockAllen.OAuth2/OAuth2Client.cs
@@ -37,26 +37,26 @@ namespace BrockAllen.OAuth2
         private OAuth2Client()
         {
         }
-        public OAuth2Client(ProviderType providerType, string clientID, string clientSecret)
+        public OAuth2Client(ProviderType providerType, string clientID, string clientSecret, string scope = "")
         {
-            this.RegisterProvider(providerType, clientID, clientSecret);
+            this.RegisterProvider(providerType, clientID, clientSecret, scope);
         }
 
         ConcurrentDictionary<ProviderType, Provider> providers = new ConcurrentDictionary<ProviderType, Provider>();
 
-        public void RegisterProvider(ProviderType providerType, string clientID, string clientSecret)
+        public void RegisterProvider(ProviderType providerType, string clientID, string clientSecret, string scope = "")
         {
             Provider provider = null;
             switch (providerType)
             {
                 case ProviderType.Google:
-                    provider = new GoogleProvider(clientID, clientSecret);
+                    provider = new GoogleProvider(clientID, clientSecret, scope);
                     break;
                 case ProviderType.Live:
-                    provider = new LiveProvider(clientID, clientSecret);
+                    provider = new LiveProvider(clientID, clientSecret, scope);
                     break;
                 case ProviderType.Facebook:
-                    provider = new FacebookProvider(clientID, clientSecret);
+                    provider = new FacebookProvider(clientID, clientSecret, scope);
                     break;
             }
 

--- a/BrockAllen.OAuth2/Provider.cs
+++ b/BrockAllen.OAuth2/Provider.cs
@@ -34,12 +34,11 @@ namespace BrockAllen.OAuth2
         public string ClientSecret { get; set; }
 
         public Provider(
-            ProviderType type, string scope, 
+            ProviderType type, 
             string authorizationUrl, string tokenUrl, string profileUrl, 
             string clientID, string clientSecret)
         {
             this.ProviderType = type;
-            this.Scope = scope;
             this.AuthorizationUrl = authorizationUrl;
             this.TokenUrl = tokenUrl;
             this.ProfileUrl = profileUrl;


### PR DESCRIPTION
you can now add a scope to the Oauth2 request, in case you want more info then just the standard scope (like email). if you don't give a scope it will use the preconfigured scope.
