### PR TITLE
LinkedIn Support Oauth2

### DIFF
--- a/BrockAllen.OAuth2/BrockAllen.OAuth2.csproj
+++ b/BrockAllen.OAuth2/BrockAllen.OAuth2.csproj
@@ -80,6 +80,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="LinkedInProvider.cs" />
     <Compile Include="OAuth2Client.cs" />
     <Compile Include="Provider.cs" />
     <Compile Include="ProviderType.cs" />

--- a/BrockAllen.OAuth2/LinkedInProvider.cs
+++ b/BrockAllen.OAuth2/LinkedInProvider.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+
+namespace BrockAllen.OAuth2
+{
+    class LinkedInProvider : Provider
+    {
+        //scope is not used for now..
+        public LinkedInProvider(string clientID, string clientSecret, string scope)
+            : base(ProviderType.LinkedIn,
+                "https://www.linkedin.com/uas/oauth2/authorization",
+                "https://www.linkedin.com/uas/oauth2/accessToken",
+                "https://api.linkedin.com/v1/people/~",
+                clientID, clientSecret)
+        {
+            //ignoring the scope for now since where not geting a NameIdentifier using the scope
+            if (string.IsNullOrEmpty(scope))
+            {
+                Scope = "r_basicprofile%20r_emailaddress";
+            }
+            else
+            {
+                Scope = scope;
+            }
+        }
+
+        static Dictionary<string, string> supportedClaimTypes = new Dictionary<string, string>();
+        static LinkedInProvider()
+        {
+            supportedClaimTypes.Add("id", ClaimTypes.NameIdentifier);
+            supportedClaimTypes.Add("firstName", ClaimTypes.GivenName);
+            supportedClaimTypes.Add("lastName", ClaimTypes.Surname);
+
+        }
+
+        internal override Dictionary<string, string> SupportedClaimTypes
+        {
+            get { return supportedClaimTypes; }
+        }
+
+        protected override async Task<IEnumerable<Claim>> GetProfileClaimsAsync(AuthorizationToken token)
+        {
+
+            var url = this.ProfileUrl + ":(id,first-name,last-name)?oauth2_access_token=" + token.AccessToken;
+
+            HttpClient client = new HttpClient();
+            client.DefaultRequestHeaders.Add("x-li-format", "json");
+            var result = await client.GetAsync(url);
+            if (result.IsSuccessStatusCode)
+            {
+                var json = await result.Content.ReadAsStringAsync();
+                var profile = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
+                return GetClaimsFromProfile(profile);
+
+
+            }
+            return null;
+        }
+    }
+}

--- a/BrockAllen.OAuth2/OAuth2Client.cs
+++ b/BrockAllen.OAuth2/OAuth2Client.cs
@@ -58,6 +58,9 @@ namespace BrockAllen.OAuth2
                 case ProviderType.Facebook:
                     provider = new FacebookProvider(clientID, clientSecret, scope);
                     break;
+                case ProviderType.LinkedIn:
+                    provider = new LinkedInProvider(clientID, clientSecret, scope);
+                    break;
             }
 
             if (provider == null)

--- a/BrockAllen.OAuth2/ProviderType.cs
+++ b/BrockAllen.OAuth2/ProviderType.cs
@@ -8,6 +8,6 @@ namespace BrockAllen.OAuth2
 {
     public enum ProviderType
     {
-        Google, Live, Facebook
+        Google, Live, Facebook, LinkedIn
     }
 }

--- a/OAuth2ClientWebApp/Controllers/HomeController.cs
+++ b/OAuth2ClientWebApp/Controllers/HomeController.cs
@@ -32,6 +32,11 @@ namespace OAuth2ClientWebApp.Controllers
                 ProviderType.Live, 
                 "00000000400DF045",
                 "4L08bE3WM8Ra4rRNMv3N--un5YOBr4gx");
+
+            OAuth2Client.Instance.RegisterProvider(
+                ProviderType.LinkedIn,
+                "{Insert ClientID}",
+                "{Insert ClientSecret}");
         }
 
         public ActionResult Index()

--- a/OAuth2ClientWebApp/Views/Home/Index.cshtml
+++ b/OAuth2ClientWebApp/Views/Home/Index.cshtml
@@ -7,6 +7,7 @@
     <li>@Html.ActionLink("Google", "Login", new { type = BrockAllen.OAuth2.ProviderType.Google })</li>
     <li>@Html.ActionLink("Live", "Login", new { type = BrockAllen.OAuth2.ProviderType.Live})</li>
     <li>@Html.ActionLink("Facebook", "Login", new { type = BrockAllen.OAuth2.ProviderType.Facebook})</li>
+    <li>@Html.ActionLink("LinkedIn", "Login", new { type = BrockAllen.OAuth2.ProviderType.LinkedIn})</li>
 </ul>
 @{
     var id = System.Security.Claims.ClaimsPrincipal.Current;


### PR DESCRIPTION
Also made a linkedIn Support for Oauth2, this way seemed a bit more simple ;)
Would also be nice if we could add a Twitter version only problem is that it is Oauth not Oauth2, but if you want I could build that in. It would be nice to have so that could also be used in the thinktecture identity provider. if this or that other version gets merged, I can also add the new providers to Thinktecture and make a pull request for that if ya want.
