### PR TITLE
LinkedIn Provider

### DIFF
--- a/BrockAllen.OAuth2/BrockAllen.OAuth2.csproj
+++ b/BrockAllen.OAuth2/BrockAllen.OAuth2.csproj
@@ -83,6 +83,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Constants.cs" />
+    <Compile Include="LinkedInProvider.cs" />
     <Compile Include="OAuth2Client.cs" />
     <Compile Include="Provider.cs" />
     <Compile Include="ProviderType.cs" />

--- a/BrockAllen.OAuth2/LinkedInProvider.cs
+++ b/BrockAllen.OAuth2/LinkedInProvider.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Threading.Tasks;
+
+namespace BrockAllen.OAuth2
+{
+    class LinkedInProvider : Provider
+    {
+        public LinkedInProvider(string clientID, string clientSecret, string scope)
+            : base(ProviderType.LinkedIn,
+                "https://www.linkedin.com/uas/oauth2/authorization",
+                "https://www.linkedin.com/uas/oauth2/accessToken",
+                "https://api.linkedin.com/v1/people/~",
+                clientID, clientSecret)
+        {
+            if (scope == null)
+            {
+                Scope = "r_basicprofile r_emailaddress";
+            }
+            else
+            {
+                Scope = scope;
+            }
+        }
+
+        static Dictionary<string, string> supportedClaimTypes = new Dictionary<string, string>();
+        
+        static LinkedInProvider()
+        {
+            supportedClaimTypes.Add("id", ClaimTypes.NameIdentifier);
+            supportedClaimTypes.Add("first-name", ClaimTypes.GivenName);
+            supportedClaimTypes.Add("last-name", ClaimTypes.Surname);
+            supportedClaimTypes.Add("email-address", ClaimTypes.Email);
+        }
+
+        protected async override Task<IEnumerable<Claim>> GetProfileClaimsAsync(AuthorizationToken token)
+        {
+            var url = this.ProfileUrl;
+
+            //Create Field Selectors for request
+            url += ":(";
+
+            for (int i = 0; i < supportedClaimTypes.Count; i++)
+            {
+                url += supportedClaimTypes.ElementAt(i).Key;
+                if ((i + 1) < supportedClaimTypes.Count) url += ",";
+            }
+
+            url += ")?oauth2_access_token=" + token.AccessToken;
+
+            var client = new HttpClient();
+            var request = new HttpRequestMessage(HttpMethod.Get,url);
+
+            //LinkedIn defaults to xml response unless format header is added to request
+            request.Headers.Add("x-li-format","json");
+
+            var result = await client.SendAsync(request);
+            if (result.IsSuccessStatusCode)
+            {
+                var json = await result.Content.ReadAsStringAsync();
+                var profile = Newtonsoft.Json.JsonConvert.DeserializeObject<Dictionary<string, object>>(json);
+                return GetClaimsFromProfile(profile);
+            }
+
+            return null;
+        }
+
+        protected override IEnumerable<Claim> GetClaimsFromProfile(Dictionary<string, object> profile)
+        {
+            //Camelize the keys in the dictionary to match LinkedIn's xml to json transformation
+            var claimMap = this.SupportedClaimTypes.Camelize();
+
+            var query =
+                from key in profile.Keys
+                where claimMap.Keys.Contains(key) && profile[key] != null
+                select new Claim(claimMap[key], profile[key].ToString(), ClaimValueTypes.String, this.Name);
+
+            return query;
+        }
+
+        internal override Dictionary<string, string> SupportedClaimTypes
+        {
+            get { return supportedClaimTypes; }
+        }
+    }
+
+    public static class LinkedInDictionaryExtension
+    {
+        public static Dictionary<string, string> Camelize(
+            this Dictionary<string, string> dict)
+        {
+            if (dict.Count.Equals(0)) return dict;
+
+            var nudict = new Dictionary<string, string>(dict.Count);
+
+            foreach (var key in dict.Keys)
+            {
+                //Remove hyphens and produce camelcased string of words
+                var hyphenSubStrings = key.Split('-');
+                if (hyphenSubStrings.Length < 1) continue;
+
+                var head = hyphenSubStrings[0];
+                var humps = string.Empty;
+
+                //UpperCase first character of remaining substrings
+                for (int i = 1; i < hyphenSubStrings.Length; i++)
+                {
+                    var ss = hyphenSubStrings[i];
+                    humps += ss.Substring(0, 1).ToUpper();
+                    humps += ss.Substring(1, ss.Length - 1);
+                }
+
+                var newKey = head + humps;
+
+                nudict.Add(newKey, dict[key]);
+            }
+
+            return nudict;
+        }
+    }
+}

--- a/BrockAllen.OAuth2/OAuth2Client.cs
+++ b/BrockAllen.OAuth2/OAuth2Client.cs
@@ -69,6 +69,9 @@ namespace BrockAllen.OAuth2
                 case ProviderType.Facebook:
                     provider = new FacebookProvider(clientID, clientSecret, scope);
                     break;
+                case ProviderType.LinkedIn:
+                    provider = new LinkedInProvider(clientID,clientSecret,scope);
+                    break;
             }
 
             if (provider == null)

--- a/BrockAllen.OAuth2/ProviderType.cs
+++ b/BrockAllen.OAuth2/ProviderType.cs
@@ -8,6 +8,6 @@ namespace BrockAllen.OAuth2
 {
     public enum ProviderType
     {
-        Google, Live, Facebook
+        Google, Live, Facebook, LinkedIn
     }
 }

--- a/OAuth2ClientWebApp/Controllers/HomeController.cs
+++ b/OAuth2ClientWebApp/Controllers/HomeController.cs
@@ -32,6 +32,11 @@ namespace OAuth2ClientWebApp.Controllers
                 ProviderType.Live, 
                 "00000000400DF045",
                 "4L08bE3WM8Ra4rRNMv3N--un5YOBr4gx");
+
+            OAuth2Client.Instance.RegisterProvider(
+                ProviderType.LinkedIn,
+                "api-key",
+                "secret-key");
         }
 
         public ActionResult Index()

--- a/OAuth2ClientWebApp/Views/Home/Index.cshtml
+++ b/OAuth2ClientWebApp/Views/Home/Index.cshtml
@@ -7,6 +7,7 @@
     <li>@Html.ActionLink("Google", "Login", new { type = BrockAllen.OAuth2.ProviderType.Google })</li>
     <li>@Html.ActionLink("Live", "Login", new { type = BrockAllen.OAuth2.ProviderType.Live})</li>
     <li>@Html.ActionLink("Facebook", "Login", new { type = BrockAllen.OAuth2.ProviderType.Facebook})</li>
+    <li>@Html.ActionLink("LinkedIn","Login", new { type = BrockAllen.OAuth2.ProviderType.LinkedIn})</li>
 </ul>
 @{
     var id = System.Security.Claims.ClaimsPrincipal.Current;


### PR DESCRIPTION
Focused on a design that isolates changes to the new subclass, guarding
from impact to other providers or complicating the Provider superclass.

Improvements
1. json response preference indicated via header instead of querystring
2. xml to json key conversion for claims matching via extension method
3. basicprofile + email for default scope instead of full to fulfill simpler authentication purposes
4. SupportedClaimTypes translated to field selectors when getting Profile Claims.
