### PR TITLE
Enable extensibility with other providers

### DIFF
--- a/BrockAllen.OAuth2/AuthorizationContext.cs
+++ b/BrockAllen.OAuth2/AuthorizationContext.cs
@@ -8,9 +8,9 @@ using System.Threading.Tasks;
 
 namespace BrockAllen.OAuth2
 {
-    class AuthorizationContext
+    public class AuthorizationContext
     {
-        public ProviderType ProviderType { get; set; }
+        public string ProviderType { get; set; }
         public string ReturnUrl { get; set; }
         public string State { get; set; }
 

--- a/BrockAllen.OAuth2/AuthorizationRedirect.cs
+++ b/BrockAllen.OAuth2/AuthorizationRedirect.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace BrockAllen.OAuth2
 {
-    class AuthorizationRedirect
+    public class AuthorizationRedirect
     {
         public string AuthorizationUrl { get; set; }
         public string State { get; set; }

--- a/BrockAllen.OAuth2/AuthorizationToken.cs
+++ b/BrockAllen.OAuth2/AuthorizationToken.cs
@@ -9,7 +9,7 @@ using System.Web.Security;
 
 namespace BrockAllen.OAuth2
 {
-    class AuthorizationToken
+    public class AuthorizationToken
     {
         public static AuthorizationToken FromJson(string json)
         {

--- a/BrockAllen.OAuth2/BrockAllen.OAuth2.csproj
+++ b/BrockAllen.OAuth2/BrockAllen.OAuth2.csproj
@@ -38,13 +38,17 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Newtonsoft.Json.4.5.11\lib\net40\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.5.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
+    <Reference Include="System.IdentityModel.Selectors" />
     <Reference Include="System.IdentityModel.Services" />
+    <Reference Include="System.IdentityModel.Tokens.Jwt">
+      <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.1.0.0\lib\net45\System.IdentityModel.Tokens.Jwt.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web" />
@@ -77,9 +81,9 @@
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
-    <Reference Include="Thinktecture.IdentityModel, Version=2.4.2.0, Culture=neutral, processorArchitecture=MSIL">
+    <Reference Include="Thinktecture.IdentityModel, Version=3.6.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\Thinktecture.IdentityModel.2.4.2\lib\net45\Thinktecture.IdentityModel.dll</HintPath>
+      <HintPath>..\packages\Thinktecture.IdentityModel.3.6.0\lib\net45\Thinktecture.IdentityModel.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/BrockAllen.OAuth2/FacebookProvider.cs
+++ b/BrockAllen.OAuth2/FacebookProvider.cs
@@ -11,7 +11,7 @@ namespace BrockAllen.OAuth2
     class FacebookProvider : Provider
     {
         public FacebookProvider(string clientID, string clientSecret, string scope)
-            : base(ProviderType.Facebook,                
+            : base("facebook",                
                 "https://www.facebook.com/dialog/oauth",
                 "https://graph.facebook.com/oauth/access_token",
                 "https://graph.facebook.com/me",
@@ -40,8 +40,8 @@ namespace BrockAllen.OAuth2
             supportedClaimTypes.Add("locale", ClaimTypes.Locality);
             supportedClaimTypes.Add("email", ClaimTypes.Email);
         }
-        
-        internal override Dictionary<string, string> SupportedClaimTypes
+
+        protected override Dictionary<string, string> SupportedClaimTypes
         {
             get { return supportedClaimTypes; }
         }

--- a/BrockAllen.OAuth2/GoogleProvider.cs
+++ b/BrockAllen.OAuth2/GoogleProvider.cs
@@ -12,7 +12,7 @@ namespace BrockAllen.OAuth2
 
 
         public GoogleProvider(string clientID, string clientSecret, string scope)
-            : base(ProviderType.Google,                
+            : base("google",                
                 "https://accounts.google.com/o/oauth2/auth",
                 "https://accounts.google.com/o/oauth2/token",
                 "https://www.googleapis.com/oauth2/v1/userinfo",
@@ -42,7 +42,7 @@ namespace BrockAllen.OAuth2
             supportedClaimTypes.Add("locale", ClaimTypes.Locality);
         }
         
-        internal override Dictionary<string, string> SupportedClaimTypes
+        protected override Dictionary<string, string> SupportedClaimTypes
         {
             get { return supportedClaimTypes; }
         }

--- a/BrockAllen.OAuth2/LinkedInProvider.cs
+++ b/BrockAllen.OAuth2/LinkedInProvider.cs
@@ -12,7 +12,7 @@ namespace BrockAllen.OAuth2
     class LinkedInProvider : Provider
     {
         public LinkedInProvider(string clientID, string clientSecret, string scope)
-            : base(ProviderType.LinkedIn,
+            : base("linkedin",
                 "https://www.linkedin.com/uas/oauth2/authorization",
                 "https://www.linkedin.com/uas/oauth2/accessToken",
                 "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,email-address,picture-url,formatted-name,location:(country:(code)),public-profile-url)",
@@ -56,8 +56,8 @@ namespace BrockAllen.OAuth2
             supportedClaimTypes.Add("location", ClaimTypes.Locality);
             supportedClaimTypes.Add("pictureUrl", ClaimTypes.UserData);
         }
-        
-        internal override Dictionary<string, string> SupportedClaimTypes
+
+        protected override Dictionary<string, string> SupportedClaimTypes
         {
             get { return supportedClaimTypes; }
         }

--- a/BrockAllen.OAuth2/LiveProvider.cs
+++ b/BrockAllen.OAuth2/LiveProvider.cs
@@ -10,7 +10,7 @@ namespace BrockAllen.OAuth2
     class LiveProvider : Provider
     {
         public LiveProvider(string clientID, string clientSecret, string scope)
-            : base(ProviderType.Live,
+            : base("live",
                 "https://login.live.com/oauth20_authorize.srf",
                 "https://login.live.com/oauth20_token.srf",
                 "https://apis.live.net/v5.0/me", 
@@ -38,7 +38,7 @@ namespace BrockAllen.OAuth2
             supportedClaimTypes.Add("locale", ClaimTypes.Locality);
         }
         
-        internal override Dictionary<string, string> SupportedClaimTypes
+        protected override Dictionary<string, string> SupportedClaimTypes
         {
             get { return supportedClaimTypes; }
         }

--- a/BrockAllen.OAuth2/OAuth2ActionResult.cs
+++ b/BrockAllen.OAuth2/OAuth2ActionResult.cs
@@ -8,21 +8,21 @@ namespace BrockAllen.OAuth2
 {
     public class OAuth2ActionResult : System.Web.Mvc.ActionResult
     {
-        ProviderType type;
+        string type;
         string returnUrl;
         OAuth2Client client;
 
-        public OAuth2ActionResult(ProviderType type)
+        public OAuth2ActionResult(string type)
             : this(OAuth2Client.Instance, type, null)
         {
         }
         
-        public OAuth2ActionResult(ProviderType type, string returnUrl)
+        public OAuth2ActionResult(string type, string returnUrl)
             : this(OAuth2Client.Instance, type, returnUrl)
         {
         }
 
-        public OAuth2ActionResult(OAuth2Client client, ProviderType type, string returnUrl)
+        public OAuth2ActionResult(OAuth2Client client, string type, string returnUrl)
         {
             this.client = client;
             this.type = type;

--- a/BrockAllen.OAuth2/OAuth2Client.cs
+++ b/BrockAllen.OAuth2/OAuth2Client.cs
@@ -40,7 +40,7 @@ namespace BrockAllen.OAuth2
         private OAuth2Client()
         {
         }
-        public OAuth2Client(ProviderType providerType, string clientID, string clientSecret, string scope = null)
+        public OAuth2Client(string providerType, string clientID, string clientSecret, string scope = null)
         {
             this.RegisterProvider(providerType, clientID, clientSecret, scope);
         }
@@ -53,9 +53,9 @@ namespace BrockAllen.OAuth2
                 new { controller, action, area });
         }
 
-        ConcurrentDictionary<ProviderType, Provider> providers = new ConcurrentDictionary<ProviderType, Provider>();
+        ConcurrentDictionary<string, Provider> providers = new ConcurrentDictionary<string, Provider>();
 
-        public void RegisterProvider(ProviderType providerType, string clientID, string clientSecret, string scope = null)
+        public void RegisterProvider(string providerType, string clientID, string clientSecret, string scope = null)
         {
             Provider provider = null;
             switch (providerType)
@@ -74,15 +74,20 @@ namespace BrockAllen.OAuth2
                     break;
             }
 
+            RegisterProvider(provider);
+        }
+
+        public void RegisterProvider(Provider provider)
+        {
             if (provider == null)
             {
                 throw new ArgumentException("Invalid provider type");
             }
 
-            providers[providerType] = provider;
+            providers[provider.ProviderType] = provider;
         }
 
-        internal Provider GetProvider(ProviderType providerType)
+        internal Provider GetProvider(string providerType)
         {
             var provider = providers[providerType];
             if (provider == null)
@@ -93,7 +98,7 @@ namespace BrockAllen.OAuth2
         }
 
         public void RedirectToAuthorizationProvider(
-            ProviderType providerType, string returnUrl = null)
+            string providerType, string returnUrl = null)
         {
             var provider = this.GetProvider(providerType);
 

--- a/BrockAllen.OAuth2/OAuthAreaRegistration.cs
+++ b/BrockAllen.OAuth2/OAuthAreaRegistration.cs
@@ -37,7 +37,7 @@ namespace BrockAllen.OAuth2
                 {
                     try
                     {
-                        var type = (ProviderType)Enum.Parse(typeof(ProviderType), provider.Key, true);
+                        var type = provider.Key;
                         var clientID = provider.Where(x => x.key.Equals("clientID", StringComparison.OrdinalIgnoreCase)).Select(x => x.value).SingleOrDefault();
                         var clientSecret = provider.Where(x => x.key.Equals("clientSecret", StringComparison.OrdinalIgnoreCase)).Select(x => x.value).SingleOrDefault();
                         var scope = provider.Where(k => k.key.Equals("scope", StringComparison.OrdinalIgnoreCase)).Select(x=>x.value).SingleOrDefault();

--- a/BrockAllen.OAuth2/Provider.cs
+++ b/BrockAllen.OAuth2/Provider.cs
@@ -13,9 +13,9 @@ using Thinktecture.IdentityModel;
 
 namespace BrockAllen.OAuth2
 {
-    abstract class Provider
+    public abstract class Provider
     {
-        public ProviderType ProviderType { get; set; }
+        public string ProviderType { get; set; }
         public string Name
         {
             get
@@ -34,7 +34,7 @@ namespace BrockAllen.OAuth2
         public string ClientSecret { get; set; }
 
         public Provider(
-            ProviderType type,
+            string type,
             string authorizationUrl, string tokenUrl, string profileUrl,
             string clientID, string clientSecret, string accessTokenParameterName = "access_token", NameValueCollection additionalParams = null)
         {
@@ -68,7 +68,7 @@ namespace BrockAllen.OAuth2
             }
         }
 
-        internal abstract Dictionary<string, string> SupportedClaimTypes { get; }
+        protected abstract Dictionary<string, string> SupportedClaimTypes { get; }
 
         public AuthorizationRedirect GetRedirect()
         {
@@ -109,8 +109,9 @@ namespace BrockAllen.OAuth2
                 return new AuthorizationToken { Error = error };
             }
 
+            // state is RECOMMENDED but not REQUIRED
             string state = queryString["state"];
-            if (ctx.State != state)
+            if (state != null && ctx.State != state)
             {
                 return new AuthorizationToken { Error = "State does not match." };
             }

--- a/BrockAllen.OAuth2/ProviderType.cs
+++ b/BrockAllen.OAuth2/ProviderType.cs
@@ -6,8 +6,12 @@ using System.Threading.Tasks;
 
 namespace BrockAllen.OAuth2
 {
-    public enum ProviderType
+    public class ProviderType
     {
-        Google, Live, Facebook, LinkedIn
+        public const string Google = "google";
+        public const string Live = "live";
+        public const string Facebook = "facebook";
+        public const string LinkedIn = "linkedin";
+        public const string MyAxpo = "myaxpo";
     }
 }

--- a/BrockAllen.OAuth2/packages.config
+++ b/BrockAllen.OAuth2/packages.config
@@ -4,6 +4,7 @@
   <package id="Microsoft.AspNet.Razor" version="2.0.20715.0" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="2.0.20710.0" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="4.5.11" targetFramework="net45" />
-  <package id="Thinktecture.IdentityModel" version="2.4.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="5.0.8" targetFramework="net45" />
+  <package id="System.IdentityModel.Tokens.Jwt" version="1.0.0" targetFramework="net45" />
+  <package id="Thinktecture.IdentityModel" version="3.6.0" targetFramework="net45" />
 </packages>

--- a/OAuth2ClientWebApp/Controllers/HomeController.cs
+++ b/OAuth2ClientWebApp/Controllers/HomeController.cs
@@ -48,7 +48,7 @@ namespace OAuth2ClientWebApp.Controllers
             return View();
         }
         
-        public ActionResult Login(ProviderType type)
+        public ActionResult Login(string type)
         {
             // 1st param is which OAuth2 provider to use
             // 2nd param is what URL to send the user once all the login magic is done


### PR DESCRIPTION
- ProviderType is now just a string.
- Makes most classes 'public'

Signed-off-by: AndreaCuneo andrea.cuneo@ark-energy.eu
