### PR TITLE
Support for passing in additional parameters when registering provider.

### DIFF
--- a/BrockAllen.OAuth2/FacebookProvider.cs
+++ b/BrockAllen.OAuth2/FacebookProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
@@ -10,12 +11,12 @@ namespace BrockAllen.OAuth2
 {
     class FacebookProvider : Provider
     {
-        public FacebookProvider(string clientID, string clientSecret, string scope)
-            : base(ProviderType.Facebook,                
+        public FacebookProvider(string clientID, string clientSecret, string scope, NameValueCollection additionalParams = null)
+            : base(ProviderType.Facebook,
                 "https://www.facebook.com/dialog/oauth",
                 "https://graph.facebook.com/oauth/access_token",
                 "https://graph.facebook.com/me",
-                clientID, clientSecret)
+                clientID, clientSecret, additionalParams: additionalParams)
         {
             if (scope == null)
             {
@@ -40,7 +41,7 @@ namespace BrockAllen.OAuth2
             supportedClaimTypes.Add("locale", ClaimTypes.Locality);
             supportedClaimTypes.Add("email", ClaimTypes.Email);
         }
-        
+
         internal override Dictionary<string, string> SupportedClaimTypes
         {
             get { return supportedClaimTypes; }

--- a/BrockAllen.OAuth2/GoogleProvider.cs
+++ b/BrockAllen.OAuth2/GoogleProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
@@ -11,12 +12,12 @@ namespace BrockAllen.OAuth2
     {
 
 
-        public GoogleProvider(string clientID, string clientSecret, string scope)
-            : base(ProviderType.Google,                
+        public GoogleProvider(string clientID, string clientSecret, string scope, NameValueCollection additionalParams = null)
+            : base(ProviderType.Google,
                 "https://accounts.google.com/o/oauth2/auth",
                 "https://accounts.google.com/o/oauth2/token",
                 "https://www.googleapis.com/oauth2/v1/userinfo",
-                clientID, clientSecret)
+                clientID, clientSecret, additionalParams: additionalParams)
         {
             if (scope == null)
             {
@@ -41,7 +42,7 @@ namespace BrockAllen.OAuth2
             supportedClaimTypes.Add("link", ClaimTypes.Webpage);
             supportedClaimTypes.Add("locale", ClaimTypes.Locality);
         }
-        
+
         internal override Dictionary<string, string> SupportedClaimTypes
         {
             get { return supportedClaimTypes; }

--- a/BrockAllen.OAuth2/LinkedInProvider.cs
+++ b/BrockAllen.OAuth2/LinkedInProvider.cs
@@ -11,12 +11,12 @@ namespace BrockAllen.OAuth2
 {
     class LinkedInProvider : Provider
     {
-        public LinkedInProvider(string clientID, string clientSecret, string scope)
+        public LinkedInProvider(string clientID, string clientSecret, string scope, NameValueCollection additionalParams = null)
             : base(ProviderType.LinkedIn,
                 "https://www.linkedin.com/uas/oauth2/authorization",
                 "https://www.linkedin.com/uas/oauth2/accessToken",
                 "https://api.linkedin.com/v1/people/~:(id,first-name,last-name,email-address,picture-url,formatted-name,location:(country:(code)),public-profile-url)",
-                clientID, clientSecret, "oauth2_access_token", new NameValueCollection(){ { "format", "json" } })
+                clientID, clientSecret, "oauth2_access_token", LinkedInProvider.AdditionalParameters(additionalParams))
         {
             if (scope == null)
             {
@@ -26,6 +26,18 @@ namespace BrockAllen.OAuth2
             {
                 Scope = scope;
             }
+        }
+
+        private static NameValueCollection AdditionalParameters(NameValueCollection additionalParams)
+        {
+            if (additionalParams == null)
+            {
+                additionalParams = new NameValueCollection();
+            }
+
+            additionalParams.Add("format", "json");
+
+            return additionalParams;
         }
 
         protected override IEnumerable<Claim> GetClaimsFromProfile(Dictionary<string, object> profile)
@@ -38,7 +50,7 @@ namespace BrockAllen.OAuth2
             claims.Remove(localityClaim);
 
             localityClaim = new Claim(localityClaim.Type, location.Country.Code);
-            
+
             claims.Add(localityClaim);
 
             return claims;
@@ -56,12 +68,12 @@ namespace BrockAllen.OAuth2
             supportedClaimTypes.Add("location", ClaimTypes.Locality);
             supportedClaimTypes.Add("pictureUrl", ClaimTypes.UserData);
         }
-        
+
         internal override Dictionary<string, string> SupportedClaimTypes
         {
             get { return supportedClaimTypes; }
         }
-        
+
         private class LinkedInLocation
         {
             [JsonProperty("country")]

--- a/BrockAllen.OAuth2/LiveProvider.cs
+++ b/BrockAllen.OAuth2/LiveProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.Linq;
 using System.Security.Claims;
 using System.Text;
@@ -9,12 +10,12 @@ namespace BrockAllen.OAuth2
 {
     class LiveProvider : Provider
     {
-        public LiveProvider(string clientID, string clientSecret, string scope)
+        public LiveProvider(string clientID, string clientSecret, string scope, NameValueCollection additionalParameters = null)
             : base(ProviderType.Live,
                 "https://login.live.com/oauth20_authorize.srf",
                 "https://login.live.com/oauth20_token.srf",
-                "https://apis.live.net/v5.0/me", 
-                clientID, clientSecret)
+                "https://apis.live.net/v5.0/me",
+                clientID, clientSecret, additionalParams: additionalParameters)
         {
             if (scope == null)
             {
@@ -37,7 +38,7 @@ namespace BrockAllen.OAuth2
             supportedClaimTypes.Add("gender", ClaimTypes.Gender);
             supportedClaimTypes.Add("locale", ClaimTypes.Locality);
         }
-        
+
         internal override Dictionary<string, string> SupportedClaimTypes
         {
             get { return supportedClaimTypes; }
@@ -54,7 +55,7 @@ namespace BrockAllen.OAuth2
             {
                 profile.Remove("emails");
                 var json = emails.ToString();
-                var emailsObj = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType(json, new { preferred="" });
+                var emailsObj = Newtonsoft.Json.JsonConvert.DeserializeAnonymousType(json, new { preferred = "" });
                 if (emailsObj != null && !String.IsNullOrWhiteSpace(emailsObj.preferred))
                 {
                     profile.Add("email", emailsObj.preferred);

--- a/BrockAllen.OAuth2/OAuth2Client.cs
+++ b/BrockAllen.OAuth2/OAuth2Client.cs
@@ -48,29 +48,29 @@ namespace BrockAllen.OAuth2
         public static void RegisterCustomOAuthCallback(RouteCollection routes, string action, string controller, string area = null)
         {
             routes.MapRoute(
-                "OAuthCallback", 
-                OAuth2Client.OAuthCallbackUrl, 
+                "OAuthCallback",
+                OAuth2Client.OAuthCallbackUrl,
                 new { controller, action, area });
         }
 
         ConcurrentDictionary<ProviderType, Provider> providers = new ConcurrentDictionary<ProviderType, Provider>();
 
-        public void RegisterProvider(ProviderType providerType, string clientID, string clientSecret, string scope = null)
+        public void RegisterProvider(ProviderType providerType, string clientID, string clientSecret, string scope = null, NameValueCollection additionalParameters = null)
         {
             Provider provider = null;
             switch (providerType)
             {
                 case ProviderType.Google:
-                    provider = new GoogleProvider(clientID, clientSecret, scope);
+                    provider = new GoogleProvider(clientID, clientSecret, scope, additionalParameters);
                     break;
                 case ProviderType.Live:
-                    provider = new LiveProvider(clientID, clientSecret, scope);
+                    provider = new LiveProvider(clientID, clientSecret, scope, additionalParameters);
                     break;
                 case ProviderType.Facebook:
-                    provider = new FacebookProvider(clientID, clientSecret, scope);
+                    provider = new FacebookProvider(clientID, clientSecret, scope, additionalParameters);
                     break;
                 case ProviderType.LinkedIn:
-                    provider = new LinkedInProvider(clientID, clientSecret, scope);
+                    provider = new LinkedInProvider(clientID, clientSecret, scope, additionalParameters);
                     break;
             }
 
@@ -100,8 +100,8 @@ namespace BrockAllen.OAuth2
             var redirect = provider.GetRedirect();
             var authCtx = new AuthorizationContext
             {
-                ProviderType = providerType, 
-                ReturnUrl = returnUrl, 
+                ProviderType = providerType,
+                ReturnUrl = returnUrl,
                 State = redirect.State
             };
             SaveContext(authCtx);
@@ -115,9 +115,9 @@ namespace BrockAllen.OAuth2
             var authCtx = GetContext();
             if (authCtx == null)
             {
-                return new CallbackResult 
-                { 
-                    Error = "No Authorization Context Cookie" 
+                return new CallbackResult
+                {
+                    Error = "No Authorization Context Cookie"
                 };
             }
             var provider = GetProvider(authCtx.ProviderType);
@@ -127,14 +127,14 @@ namespace BrockAllen.OAuth2
             result.ProviderName = authCtx.ProviderType.ToString();
             return result;
         }
-        
+
         void SaveContext(AuthorizationContext authCtx)
         {
             var ctx = HttpContext.Current;
-            
+
             var json = authCtx.ToJson();
             var data = Protect(Encoding.UTF8.GetBytes(json));
-            
+
             var cookie = new HttpCookie(AuthorizationContextCookieName, data);
             cookie.Secure = ctx.Request.IsSecureConnection;
             cookie.HttpOnly = true;
@@ -147,7 +147,7 @@ namespace BrockAllen.OAuth2
             var ctx = HttpContext.Current;
             var cookie = ctx.Request.Cookies[AuthorizationContextCookieName];
             if (cookie == null) return null;
-            
+
             var json = Encoding.UTF8.GetString(Unprotect(cookie.Value));
             var authCtx = AuthorizationContext.Parse(json);
 


### PR DESCRIPTION
Exposed additionalparameters dictionary. This allows us to pass in the fields=email when requesting for email from facebook graph api. https://graph.facebook.com/v2.4/me?fields=id,name,email
